### PR TITLE
Changes URL declaration to avoid deprecated pattern

### DIFF
--- a/advanced_filters/urls.py
+++ b/advanced_filters/urls.py
@@ -1,10 +1,8 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from advanced_filters.views import GetFieldChoices
 
-urlpatterns = patterns(
-    # API
-    '',
+urlpatterns = [
     url(r'^field_choices/(?P<model>.+)/(?P<field_name>.+)/?',
         GetFieldChoices.as_view(),
         name='afilters_get_field_choices'),
@@ -13,4 +11,4 @@ urlpatterns = patterns(
     url(r'^field_choices/$',
         GetFieldChoices.as_view(),
         name='afilters_get_field_choices'),
-)
+]


### PR DESCRIPTION
Hello,

This is a small PR to remove a warning message (RemovedInDjango110Warning) related to the use of django.conf.urls.patterns() when declaring URLs. 

Not sure if you guys want this, but my OCD got the better of me and I decided to submit this 😄 

Thanks.