### PR TITLE
initialize select2 widget

### DIFF
--- a/advanced_filters/static/advanced-filters/advanced-filters.js
+++ b/advanced_filters/static/advanced-filters/advanced-filters.js
@@ -130,8 +130,8 @@ var OperatorHandlers = function($) {
 				if ($(this).val() != before_change) self.field_selected(this);
 				$(this).data('pre_change', $(this).val());
 			}).change();
+			self.initialize_select2(this)
 		});
-		self.initialize_select2(this)
 	};
 
 	self.destroy = function() {

--- a/advanced_filters/static/advanced-filters/advanced-filters.js
+++ b/advanced_filters/static/advanced-filters/advanced-filters.js
@@ -70,7 +70,11 @@ var OperatorHandlers = function($) {
 						  MODEL_LABEL) + '/' + field;
 		var input = $(elm).parents('tr').find('input.query-value');
 		input.select2("destroy");
+		var value = input.val();
 		$.get(choices_url, function(data) {
+			if (value) {
+				data.results.push({'id': value, 'text': value})
+			}
 			input.select2({'data': data, 'createSearchChoice': function(term) {
                 return { 'id': term, 'text': term };
             }});
@@ -127,6 +131,7 @@ var OperatorHandlers = function($) {
 				$(this).data('pre_change', $(this).val());
 			}).change();
 		});
+		self.initialize_select2(this)
 	};
 
 	self.destroy = function() {

--- a/advanced_filters/urls.py
+++ b/advanced_filters/urls.py
@@ -1,10 +1,8 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from advanced_filters.views import GetFieldChoices
 
-urlpatterns = patterns(
-    # API
-    '',
+urlpatterns = [
     url(r'^field_choices/(?P<model>.+)/(?P<field_name>.+)/?',
         GetFieldChoices.as_view(),
         name='afilters_get_field_choices'),
@@ -13,4 +11,4 @@ urlpatterns = patterns(
     url(r'^field_choices/$',
         GetFieldChoices.as_view(),
         name='afilters_get_field_choices'),
-)
+]


### PR DESCRIPTION
This merge request allows the select2 widget to pre-populate with the current value. It should also fix [Issue 22](https://github.com/modlinltd/django-advanced-filters/issues/22).

There is a side effect to how I fixed this, which I think is OK. If the value is not in the list returned by the ajax call it is added to the beginning of the list. This does also make it easy to switch back to the old value if you want to.

Also, if the value is in the list returned from the ajax call, it is in the list twice. This behavior is less desired, but it can be useful if you have a long list to see what the previous value was.