### PR TITLE
Fix of Max Choices bug

### DIFF
--- a/advanced_filters/static/advanced-filters/advanced-filters.js
+++ b/advanced_filters/static/advanced-filters/advanced-filters.js
@@ -71,13 +71,9 @@ var OperatorHandlers = function($) {
 		var input = $(elm).parents('tr').find('input.query-value');
 		input.select2("destroy");
 		$.get(choices_url, function(data) {
-			if (data.results.length > 0) {
-				input.select2({
-					'data': data, 'createSearchChoice': function (term) {
-						return {'id': term, 'text': term};
-					}
-				});
-			}
+			input.select2({'data': data, 'createSearchChoice': function(term) {
+                return { 'id': term, 'text': term };
+            }});
 		});
 	};
 

--- a/advanced_filters/static/advanced-filters/advanced-filters.js
+++ b/advanced_filters/static/advanced-filters/advanced-filters.js
@@ -71,9 +71,13 @@ var OperatorHandlers = function($) {
 		var input = $(elm).parents('tr').find('input.query-value');
 		input.select2("destroy");
 		$.get(choices_url, function(data) {
-			input.select2({'data': data, 'createSearchChoice': function(term) {
-                return { 'id': term, 'text': term };
-            }});
+			if (data.results.length > 0) {
+				input.select2({
+					'data': data, 'createSearchChoice': function (term) {
+						return {'id': term, 'text': term};
+					}
+				});
+			}
 		});
 	};
 

--- a/advanced_filters/tests/test_views.py
+++ b/advanced_filters/tests/test_views.py
@@ -110,6 +110,4 @@ class TestGetFieldChoicesView(TestCase):
         view_url = reverse(self.url_name, kwargs=dict(
             model='customers.Client', field_name='email'))
         res = self.client.get(view_url)
-        self.assert_json(res, {'results':
-                [{'id': 'foo@bar.com', 'text': 'foo@bar.com'}],
-        })
+        self.assert_json(res, {'results': [{'id': 'foo@bar.com', 'text': 'foo@bar.com'}]})

--- a/advanced_filters/tests/test_views.py
+++ b/advanced_filters/tests/test_views.py
@@ -100,6 +100,7 @@ class TestGetFieldChoicesView(TestCase):
     def test_more_than_max_database_choices(self):
         factories.Client.create_batch(5, assigned_to=self.user)
         view_url = reverse(self.url_name, kwargs=dict(
-            model='customers.Client', field_name='first_name'))
+            model='customers.Client', field_name='id'))
         res = self.client.get(view_url)
+        print(res)
         self.assert_json(res, {'results': []})

--- a/advanced_filters/tests/test_views.py
+++ b/advanced_filters/tests/test_views.py
@@ -103,3 +103,13 @@ class TestGetFieldChoicesView(TestCase):
             model='customers.Client', field_name='id'))
         res = self.client.get(view_url)
         self.assert_json(res, {'results': []})
+
+    @override_settings(ADVANCED_FILTERS_MAX_CHOICES=4)
+    def test_distinct_database_choices(self):
+        factories.Client.create_batch(5, assigned_to=self.user, email="foo@bar.com")
+        view_url = reverse(self.url_name, kwargs=dict(
+            model='customers.Client', field_name='email'))
+        res = self.client.get(view_url)
+        self.assert_json(res, {'results':
+                [{'id': 'foo@bar.com', 'text': 'foo@bar.com'}],
+        })

--- a/advanced_filters/tests/test_views.py
+++ b/advanced_filters/tests/test_views.py
@@ -102,5 +102,4 @@ class TestGetFieldChoicesView(TestCase):
         view_url = reverse(self.url_name, kwargs=dict(
             model='customers.Client', field_name='id'))
         res = self.client.get(view_url)
-        print(res)
         self.assert_json(res, {'results': []})

--- a/advanced_filters/urls.py
+++ b/advanced_filters/urls.py
@@ -1,10 +1,8 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from advanced_filters.views import GetFieldChoices
 
-urlpatterns = patterns(
-    # API
-    '',
+urlpatterns = [
     url(r'^field_choices/(?P<model>.+)/(?P<field_name>.+)/?',
         GetFieldChoices.as_view(),
         name='afilters_get_field_choices'),
@@ -13,4 +11,4 @@ urlpatterns = patterns(
     url(r'^field_choices/$',
         GetFieldChoices.as_view(),
         name='afilters_get_field_choices'),
-)
+]

--- a/advanced_filters/views.py
+++ b/advanced_filters/views.py
@@ -69,8 +69,8 @@ class GetFieldChoices(CsrfExemptMixin, StaffuserRequiredMixin,
                 logger.debug('No choices calculated for field %s of type %s',
                              field, type(field))
             else:
-                choices = model_obj.objects.values_list(field.name, flat=True).distinct()
-                if choices.count() < max_choices:
+                choices = set(model_obj.objects.values_list(field.name, flat=True))
+                if len(choices) <= max_choices:
                     choices = zip(choices, choices)
                     logger.debug('Choices found for field %s: %s',
                                  field.name, choices)

--- a/advanced_filters/views.py
+++ b/advanced_filters/views.py
@@ -69,8 +69,8 @@ class GetFieldChoices(CsrfExemptMixin, StaffuserRequiredMixin,
                 logger.debug('No choices calculated for field %s of type %s',
                              field, type(field))
             else:
-                choices = set(model_obj.objects.values_list(field.name, flat=True))
-                if len(choices) <= max_choices:
+                choices = model_obj.objects.values_list(field.name, flat=True).distinct()
+                if choices.count() <= max_choices:
                     choices = zip(choices, choices)
                     logger.debug('Choices found for field %s: %s',
                                  field.name, choices)

--- a/advanced_filters/views.py
+++ b/advanced_filters/views.py
@@ -69,9 +69,8 @@ class GetFieldChoices(CsrfExemptMixin, StaffuserRequiredMixin,
                 logger.debug('No choices calculated for field %s of type %s',
                              field, type(field))
             else:
-                choices = model_obj.objects.values_list(field.name, flat=True)
+                choices = model_obj.objects.values_list(field.name, flat=True).distinct()
                 if choices.count() < max_choices:
-                    choices = set(choices)
                     choices = zip(choices, choices)
                     logger.debug('Choices found for field %s: %s',
                                  field.name, choices)


### PR DESCRIPTION
Max choices used to only send data to the front end if the total number of _instances_ of the model was less than the max choices setting.

I refactored the code so that the set was created earlier. This way the view will return data if the number of _unique_ values is less than the max choices setting.
