### PR TITLE
don't override original change_list_templates in AdminAdvancedFiltersMixin

### DIFF
--- a/advanced_filters/admin.py
+++ b/advanced_filters/admin.py
@@ -56,11 +56,16 @@ class AdvancedListFilters(admin.SimpleListFilter):
 
 class AdminAdvancedFiltersMixin(object):
     """ Generic AdvancedFilters mixin """
-    change_list_template = "admin/advanced_filters.html"
+    advanced_change_list_template = "admin/advanced_filters.html"
     advanced_filter_form = AdvancedFilterForm
 
     def __init__(self, *args, **kwargs):
         super(AdminAdvancedFiltersMixin, self).__init__(*args, **kwargs)
+        if self.change_list_template:
+            self.original_change_list_template = self.change_list_template
+        else:
+            self.original_change_list_template = "admin/change_list.html"
+        self.change_list_template = self.advanced_change_list_template
         # add list filters to filters
         self.list_filter = (AdvancedListFilters,) + tuple(self.list_filter)
 
@@ -89,6 +94,7 @@ class AdminAdvancedFiltersMixin(object):
         adv_filters_form = self.advanced_filter_form(
             data=data, model_admin=self, extra_form=True)
         extra_context.update({
+            'original_change_list_template': self.original_change_list_template,
             'advanced_filters': adv_filters_form,
             'current_afilter': request.GET.get('_afilter'),
             'app_label': self.opts.app_label,

--- a/advanced_filters/templates/admin/advanced_filters.html
+++ b/advanced_filters/templates/admin/advanced_filters.html
@@ -1,4 +1,4 @@
-{% extends "admin/change_list.html" %}
+{% extends original_change_list_template %}
 {% load i18n static admin_modify %}
 {# django == 1.5 support #}
 {# {% load cycle from future %} #}


### PR DESCRIPTION
I use `django-advanced-filters` together with `django-import-export`. Now the import/export buttons disappear when `AdminAdvancedFiltersMixin` is added, because the it overrides the original `extends` in the template to `admin/change_list.html`. This change makes available the `change_list_template` that was set before in the `ModelAdmin` class.