### PR TITLE
fix error when one missing range parameter caused error

### DIFF
--- a/advanced_filters/forms.py
+++ b/advanced_filters/forms.py
@@ -45,6 +45,13 @@ SELECT2_JS = getattr(settings, 'SELECT2_JS', 'select2/select2.min.js')
 SELECT2_CSS = getattr(settings, 'SELECT2_CSS', 'select2/select2.min.css')
 
 
+def date_to_string(timestamp):
+    if timestamp:
+        return dt.fromtimestamp(timestamp).strftime('%Y-%m-%d')
+    else:
+        return ""
+
+
 class AdvancedFilterQueryForm(CleanWhiteSpacesMixin, forms.Form):
     """ Build the query from field, operator and value """
     OPERATORS = (
@@ -146,10 +153,9 @@ class AdvancedFilterQueryForm(CleanWhiteSpacesMixin, forms.Form):
 
         if isinstance(query_data.get('value'),
                       list) and query_data['operator'] == 'range':
-            dtfrom = dt.fromtimestamp(query_data.get('value_from', 0))
-            dtto = dt.fromtimestamp(query_data.get('value_to', 0))
-            query_data['value'] = ','.join([dtfrom.strftime('%Y-%m-%d'),
-                                            dtto.strftime('%Y-%m-%d')])
+            date_from = date_to_string(query_data.get('value_from'))
+            date_to = date_to_string(query_data.get('value_to'))
+            query_data['value'] = ','.join([date_from, date_to])
 
         return query_data
 

--- a/advanced_filters/static/advanced-filters/advanced-filters.js
+++ b/advanced_filters/static/advanced-filters/advanced-filters.js
@@ -12,12 +12,12 @@ var OperatorHandlers = function($) {
 		var $from = $('<input type="text">');
 		$from.attr("name", "form-" + form_num + "-value_from");
 		$from.attr("id", "id_form-" + form_num + "-value_from");
-		$from.attr("placeholder", gettext('Start date'));
+		$from.attr("placeholder", gettext('Start date (YYYY-MM-DD)'));
 		$from.addClass('query-dt-from');
 		var $to = $('<input type="text">');
 		$to.attr("name", "form-" + form_num + "-value_to");
 		$to.attr("id", "id_form-" + form_num + "-value_to");
-		$to.attr("placeholder", gettext('End date'));
+		$to.attr("placeholder", gettext('End date (YYYY-MM-DD)'));
 		$to.addClass('query-dt-to');
 
 		self.val_input.parent().prepend($to);

--- a/advanced_filters/tests/test_forms.py
+++ b/advanced_filters/tests/test_forms.py
@@ -44,6 +44,20 @@ class TestQueryForm(TestCase):
         assert d1.replace(tzinfo=None) == datetime(1980, 1, 1)
         assert d2.replace(tzinfo=None) == datetime(1990, 1, 1)
 
+    def test_range_value_one_missing(self):
+        """ Test, that range filter works even if one range is missing """
+        Rep = get_user_model()
+        field = {
+            'value_to': 504921600.0,
+            'negate': False,
+            'value_from': None,
+            'field': 'date_joined',
+            'value': [None, 504921600.0],
+            'operator': 'range',
+        }
+        res = AdvancedFilterQueryForm._parse_query_dict(field, Rep)
+        assert res['value'] == ',1986-01-01'
+
     def test_build_field_choices(self):
         form = AdvancedFilterQueryForm(self.fields)
         assert 'field' in form.fields


### PR DESCRIPTION
I bumped into error, that if one range of date range was not set, the entire filter page stopped working.

This tests and fixes that and even adds functionality - if one of the ranges is not set, it will filter only by the remaining boundary.

I also added required time format to the placeholder, so it is more apparent, what the user should insert.