### PR TITLE
fix(forms): add script to load jQuery globally

### DIFF
--- a/advanced_filters/forms.py
+++ b/advanced_filters/forms.py
@@ -248,6 +248,7 @@ class AdvancedFilterForm(CleanWhiteSpacesMixin, forms.ModelForm):
     class Media:
         required_js = [static('admin/js/%sjquery.min.js' %
                        ('vendor/jquery/' if USE_VENDOR_DIR else '')),
+                       static('advanced-filters/jquery_adder.js'),
                        static('orig_inlines%s.js' %
                        ('' if settings.DEBUG else '.min')),
                        static('magnific-popup/jquery.magnific-popup.js'),

--- a/advanced_filters/static/advanced-filters/jquery_adder.js
+++ b/advanced_filters/static/advanced-filters/jquery_adder.js
@@ -1,0 +1,3 @@
+(function($) {
+	if (!window.jQuery)	window.jQuery = $;
+})(window._jq || jQuery || grp.jQuery);


### PR DESCRIPTION
Adds jQuery to global vars (window.jQuery) if it was removed by Grappelli, since other packages expect it to be there.

Fixes #49