### PR TITLE
A bit of README polishing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,12 +211,6 @@ This change has a few benefits:
 3. Limit the ``AdvancedListFilters`` to limit queryset (and thus, the
    underlying options) to a specified model.
 
-Note: Since we are at the early stages of development I have skipped the
-South / 1.7 schema (new field) and data migrations (add specific model
-to all existing instances of AdvancedFilter model) migrations. Though
-this shouldn't be too difficult to do, if the need arises I can add
-migration examples.
-
 Views
 =====
 

--- a/README.rst
+++ b/README.rst
@@ -171,7 +171,7 @@ Remove
 
 Similarly to other `django
 formsets <https://docs.djangoproject.com/en/dev/topics/forms/formsets/>`__,
-used to remove the formset on submit.
+used to remove the selected line on submit.
 
 Editing previously created advanced filters
 ===========================================
@@ -193,17 +193,18 @@ Query Serialization
 Model correlation
 =================
 
-Since version 1.0, The underlying ``AdvancedFilter`` model instances are
-tightly coupled with a specific model (using the app\_label.Name model
-name), for which admin changelist they are to used and created in.
+Since version 1.0, ``AdvancedFilter`` are tightly coupled with a specific model
+using the ``model`` field and the app\_label.Name template.
+On creation, ``model`` is populated based on the admin changelist it's created
+in.
 
 This change has a few benefits:
 
-1. Admin mixin can be used with multiple ``ModelAdmin`` classes while
+1. The mixin can be used with multiple ``ModelAdmin`` classes while
    performing specific query serialization and field validation that are
    at the base of the filter functionality.
 
-2. Allows users to edit previously created filters outside of the
+2. Users can edit previously created filters outside of the
    context of a changelist, as we do in the
    ```AdvancedFilterAdmin`` <#editing-previously-created-advanced-filters>`__.
 


### PR DESCRIPTION
Thanks for a great README. 

Other then the minor edits I've made,  there are two things we can improve:

1. migrations - IMHO, post 1.0 we need to publish migrations
2. contributing guide - How do I install the dev environment, test and start coding?

regarding 1., If you'd like I can replace the paragraph about migrations with a paragraph about migrating from 0.x

Regarding 2, I'm stuck. ``python setup.py test`` crashes. Guess I'm doing something wrong. Here's the log:

```
actionid: py26-d15
msg: getenv
cmdargs: ['/Users/daonb/Source/matific/django-advanced-filters/.tox/py26-d15/bin/pip', 'install', 'Django>=1.5,<1.6', 'unittest2', '-rtest-reqs.txt']

DEPRECATION: Python 2.6 is no longer supported by the Python core team, please upgrade your Python. A future version of pip will drop support for Python 2.6
Collecting Django<1.6,>=1.5
  Using cached Django-1.5.12-py2.py3-none-any.whl
Collecting unittest2
  Using cached unittest2-1.1.0-py2.py3-none-any.whl
Collecting coveralls==0.5 (from -r test-reqs.txt (line 1))
/Users/daonb/Source/matific/django-advanced-filters/.tox/py26-d15/lib/python2.6/site-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:318: SNIMissingWarning: An HTTPS request has been made, but the SNI (Subject Name Indication) extension to TLS is not available on this platform. This may cause the server to present an incorrect TLS certificate, which can cause validation failures. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.io/en/latest/security.html#snimissingwarning.
  SNIMissingWarning
/Users/daonb/Source/matific/django-advanced-filters/.tox/py26-d15/lib/python2.6/site-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:122: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.io/en/latest/security.html#insecureplatformwarning.
  InsecurePlatformWarning
  Using cached coveralls-0.5.zip
Collecting factory-boy==2.5.2 (from -r test-reqs.txt (line 2))
  Using cached factory_boy-2.5.2-py2.py3-none-any.whl
Collecting pep8==1.6.2 (from -r test-reqs.txt (line 3))
  Using cached pep8-1.6.2-py2.py3-none-any.whl
Collecting pytest-django==2.9.1 (from -r test-reqs.txt (line 4))
  Using cached pytest_django-2.9.1-py2.py3-none-any.whl
Collecting six>=1.4 (from unittest2)
  Using cached six-1.10.0-py2.py3-none-any.whl
Collecting traceback2 (from unittest2)
  Using cached traceback2-1.4.0-py2.py3-none-any.whl
Collecting argparse (from unittest2)
  Using cached argparse-1.4.0-py2.py3-none-any.whl
Collecting PyYAML>=3.10 (from coveralls==0.5->-r test-reqs.txt (line 1))
  Using cached PyYAML-3.12.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/0n/0hzyh13d0t71246v74_pqp_r0000gp/T/pip-build-7sm0je/PyYAML/setup.py", line 83, in <module>
        from wheel.bdist_wheel import bdist_wheel
      File "/Users/daonb/Source/matific/django-advanced-filters/.tox/py26-d15/lib/python2.6/site-packages/wheel/bdist_wheel.py", line 407
        ignore=lambda x, y: {'PKG-INFO', 'requires.txt', 'SOURCES.txt',
                                       ^
    SyntaxError: invalid syntax
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/0n/0hzyh13d0t71246v74_pqp_r0000gp/T/pip-build-7sm0je/PyYAML/

```

