### PR TITLE
Fix AdvancedFilterForm Media declaration

### DIFF
--- a/advanced_filters/forms.py
+++ b/advanced_filters/forms.py
@@ -24,7 +24,6 @@ except ImportError:
 from django.db.models import Q, FieldDoesNotExist
 from django.db.models.fields import DateField
 from django.forms.formsets import formset_factory, BaseFormSet
-from django.templatetags.static import static
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 from django.utils.six.moves import range, reduce
@@ -253,16 +252,19 @@ class AdvancedFilterForm(CleanWhiteSpacesMixin, forms.ModelForm):
         fields = ('title',)
 
     class Media:
-        required_js = [static('admin/js/%sjquery.min.js' %
-                       ('vendor/jquery/' if USE_VENDOR_DIR else '')),
-                       static('advanced-filters/jquery_adder.js'),
-                       static('orig_inlines%s.js' %
-                       ('' if settings.DEBUG else '.min')),
-                       static('magnific-popup/jquery.magnific-popup.js'),
-                       static('advanced-filters/advanced-filters.js'), ]
+        required_js = [
+            'admin/js/%sjquery.min.js' % ('vendor/jquery/' if USE_VENDOR_DIR else ''),
+            'advanced-filters/jquery_adder.js',
+            'orig_inlines%s.js' % ('' if settings.DEBUG else '.min'),
+            'magnific-popup/jquery.magnific-popup.js',
+            'advanced-filters/advanced-filters.js',
+        ]
         js = required_js + [SELECT2_JS]
-        css = {'screen': [static(SELECT2_CSS), static('advanced-filters/advanced-filters.css'),
-                          static('magnific-popup/magnific-popup.css')]}
+        css = {'screen': [
+            SELECT2_CSS,
+            'advanced-filters/advanced-filters.css',
+            'magnific-popup/magnific-popup.css'
+        ]}
 
     def get_fields_from_model(self, model, fields):
         """


### PR DESCRIPTION
See https://github.com/modlinltd/django-advanced-filters/issues/60#issuecomment-351054606 for context.

@asfaltboy, this is a quite empirical modification based on [this Django documentation page](https://docs.djangoproject.com/en/1.11/topics/forms/media/#assets-as-a-static-definition).
It solves our deployment problem on Heroku, and I believe it shouldn't break anything anywhere else.

Feel free to integrate it upstream if you so wish :)



