### PR TITLE
BUGFIX - do not replace values in edit view

### DIFF
--- a/advanced_filters/static/advanced-filters/advanced-filters.js
+++ b/advanced_filters/static/advanced-filters/advanced-filters.js
@@ -70,11 +70,13 @@ var OperatorHandlers = function($) {
 						  MODEL_LABEL) + '/' + field;
 		var input = $(elm).parents('tr').find('input.query-value');
 		input.select2("destroy");
-		$.get(choices_url, function(data) {
-			input.select2({'data': data, 'createSearchChoice': function(term) {
-                return { 'id': term, 'text': term };
-            }});
-		});
+		if (input[0].value === "") {
+			$.get(choices_url, function(data) {
+				input.select2({'data': data, 'createSearchChoice': function(term) {
+			return { 'id': term, 'text': term };
+		    }});
+			});
+		};
 	};
 
 	self.field_selected = function(elm) {


### PR DESCRIPTION
When editing a pre-existing advanced filter object, the javascript is overwriting pre-existing values with a blank select 2 box like so:


![select2_bug](https://user-images.githubusercontent.com/1808790/41312437-eaf1a882-6e3b-11e8-9479-cc8f38e1b05f.gif)
 
The fix implemented here modifies the behavior like so:

![select2_fixed](https://user-images.githubusercontent.com/1808790/41312465-fd33437a-6e3b-11e8-8b7f-896add98a18d.gif)

Note that I am not much of a JS dev, so not sure this is the best way to handle the issue.