### PR TITLE
hiding value for boolean/null comparators

### DIFF
--- a/advanced_filters/static/advanced-filters/advanced-filters.js
+++ b/advanced_filters/static/advanced-filters/advanced-filters.js
@@ -56,10 +56,23 @@ var OperatorHandlers = function($) {
 		self.value = $(elm).val();
 		self.val_input = $(elm).parents('tr').find('.query-value');
 		console.log("selected operator: " + self.value);
+
 		if (self.value == "range") {
 			self.add_datepickers();
+		} else if (self.value == "istrue") {
+			self.val_input.val("True");
+		} else if (self.value == "isfalse") {
+			self.val_input.val("False");
+		} else if (self.value == "isnull") {
+			self.val_input.val("null");
 		} else {
 			self.remove_datepickers();
+		}
+
+		if ($.inArray(self.value, ["istrue","isnull","isfalse"]) > -1) {
+			self.val_input.hide();
+		} else {
+			self.val_input.show();
 		}
 	};
 


### PR DESCRIPTION
A little bit of a hack here, but does successfully hide the "value" input element when istrue, isfalse, and isnull operators are chosen. Since it technically populates the value of the element and then hides it, there will be a small annoyance if you switch it back to a field that requires input (you would see the value we stuck in there, i.e. - True/False). However, this seems less annoying than having to type "null" in the box when creating these fields.