### PR TITLE
ValueError while creating empty form

### DIFF
--- a/advanced_filters/forms.py
+++ b/advanced_filters/forms.py
@@ -216,6 +216,7 @@ class AdvancedFilterFormSet(BaseFormSet):
             auto_id=self.auto_id,
             prefix=self.add_prefix('__prefix__'),
             empty_permitted=True,
+            use_required_attribute=False,
         )
         self.add_fields(form, None)
         return form


### PR DESCRIPTION
This correction avoids the ValueError described in the issue:
https://github.com/modlinltd/django-advanced-filters/issues/86
