### PR TITLE
Add encoding='utf-8' to open() in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from setuptools.command.test import test as TestCommand
 from setuptools import setup, find_packages
 import os
 import sys
+import io
 
 from advanced_filters import __version__
 
@@ -34,9 +35,9 @@ def get_full_description():
     readme = 'README.rst'
     changelog = 'CHANGELOG.rst'
     base = os.path.dirname(__file__)
-    with open(os.path.join(base, readme)) as readme:
+    with io.open(os.path.join(base, readme), encoding='utf-8') as readme:
         README = readme.read()
-    with open(os.path.join(base, changelog)) as changelog:
+    with io.open(os.path.join(base, changelog), encoding='utf-8') as changelog:
         CHANGELOG = changelog.read()
     return '%s\n%s' % (README, CHANGELOG)
 


### PR DESCRIPTION
Currently, machines which default to CP-1252 error when reading CHANGELOG.rst (there are a few names with non-Latin characters or diacritics); `UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 2863: character maps to <undefined>`. 

By adding an `encoding='utf-8'` keyword argument to the two `open()` calls in `setup.py`'s `get_full_description`, we can prevent this error.

This change is backwards-compatible, so only a patch version bump is needed.