### PR TITLE
Bug fixes

### DIFF
--- a/advanced_filters/forms.py
+++ b/advanced_filters/forms.py
@@ -66,7 +66,7 @@ class AdvancedFilterQueryForm(CleanWhiteSpacesMixin, forms.Form):
         label=_('Operator'),
         required=True, choices=OPERATORS, initial="iexact",
         widget=forms.Select(attrs={'class': 'query-operator'}))
-    value = VaryingTypeCharField(required=True, widget=forms.TextInput(
+    value = VaryingTypeCharField(required=False, widget=forms.TextInput(
         attrs={'class': 'query-value'}), label=_('Value'))
     value_from = forms.DateTimeField(widget=forms.HiddenInput(
         attrs={'class': 'query-dt-from'}), required=False)
@@ -92,7 +92,7 @@ class AdvancedFilterQueryForm(CleanWhiteSpacesMixin, forms.Form):
             formdata = self.cleaned_data
         key = "{field}__{operator}".format(**formdata)
         if formdata['operator'] == "isnull":
-            return {key: None}
+            return {key: 'None'}
         elif formdata['operator'] == "istrue":
             return {formdata['field']: True}
         elif formdata['operator'] == "isfalse":
@@ -134,11 +134,7 @@ class AdvancedFilterQueryForm(CleanWhiteSpacesMixin, forms.Form):
         elif query_data['value'] is False:
             query_data['operator'] = "isfalse"
         else:
-            if isinstance(mfield, DateField):
-                # this is a date/datetime field
-                query_data['operator'] = "range"  # default
-            else:
-                query_data['operator'] = operator  # default
+            query_data['operator'] = operator  # default
 
         if isinstance(query_data.get('value'),
                       list) and query_data['operator'] == 'range':
@@ -167,6 +163,15 @@ class AdvancedFilterQueryForm(CleanWhiteSpacesMixin, forms.Form):
                     'value_to' in cleaned_data):
                 self.set_range_value(cleaned_data)
         return cleaned_data
+
+    def clean_value(self):
+        value = self.cleaned_data['value']
+        op = self.cleaned_data.get('operator', '')
+        list = ['istrue', 'isfalse', 'isnull']
+        if op not in list:
+            self.fields['value'].required = True
+            return self.fields['value'].clean(value)
+        return value
 
     def make_query(self, *args, **kwargs):
         """ Returns a Q object from the submitted form """

--- a/advanced_filters/static/advanced-filters/advanced-filters.js
+++ b/advanced_filters/static/advanced-filters/advanced-filters.js
@@ -34,10 +34,10 @@ var OperatorHandlers = function($) {
 		}
 		self.val_input.css({display: 'none'});
 
-		$(".hasDatepicker").datepicker("destroy");
+		try {$(".hasDatepicker").datepicker("destroy");} catch(e) {}
 		$from.addClass('vDateField');
 		$to.addClass('vDateField');
-		grappelli.initDateAndTimePicker();
+		try {grappelli.initDateAndTimePicker();} catch(e) {}
 	};
 
 	self.remove_datepickers = function() {
@@ -45,7 +45,7 @@ var OperatorHandlers = function($) {
 		if (self.val_input.parent().find('input.vDateField').length > 0) {
 			var datefields = self.val_input.parent().find('input.vDateField');
 			datefields.each(function() {
-				$(this).datepicker("destroy");
+				try {$(this).datepicker("destroy");} catch(e) {}
 			});
 			datefields.remove();
 		}
@@ -53,28 +53,46 @@ var OperatorHandlers = function($) {
 
 	self.modify_widget = function(elm) {
 		// pick a widget for the value field according to operator
+		list = ['istrue', 'isfalse', 'isnull'];
 		self.value = $(elm).val();
 		self.val_input = $(elm).parents('tr').find('.query-value');
 		console.log("selected operator: " + self.value);
+		var field = $(elm).parents('tr').find('.query-field');
+		self.initialize_select2(field);
+
 		if (self.value == "range") {
 			self.add_datepickers();
 		} else {
 			self.remove_datepickers();
+		}
+
+		var input = $(elm).parents('tr').find('input.query-value');
+		if (list.includes(self.value)) {
+			input.prop('readonly', true);
+		} else {
+			input.prop('readonly', false);
 		}
 	};
 
 	self.initialize_select2 = function(elm) {
 		// initialize select2 widget and populate field choices
 		var field = $(elm).val();
-		var choices_url = ADVANCED_FILTER_CHOICES_LOOKUP_URL + (FORM_MODEL ||
-						  MODEL_LABEL) + '/' + field;
-		var input = $(elm).parents('tr').find('input.query-value');
-		input.select2("destroy");
-		$.get(choices_url, function(data) {
-			input.select2({'data': data, 'createSearchChoice': function(term) {
-                return { 'id': term, 'text': term };
-            }});
-		});
+		var op = $(elm).parents('tr').find('.query-operator');
+		if (field.includes('__') && op.val() == 'iexact') {
+			var choices_url = ADVANCED_FILTER_CHOICES_LOOKUP_URL + (FORM_MODEL ||
+							  MODEL_LABEL) + '/' + field;
+			var input = $(elm).parents('tr').find('input.query-value');
+			input.select2("destroy");
+			$.get(choices_url, function(data) {
+				input.select2({'data': data, 'createSearchChoice': function(term) {
+	                return { 'id': term, 'text': term };
+	            }});
+			});
+		}
+		else {
+			var input = $(elm).parents('tr').find('input.query-value');
+			input.select2("destroy");
+		}
 	};
 
 	self.field_selected = function(elm) {
@@ -108,15 +126,16 @@ var OperatorHandlers = function($) {
 			// if only 1 form and it's empty, add first extra formset
 			$('[data-rules-formset] .add-row a').click();
 		}
+
 		$('.form-row select.query-operator').each(function() {
 			$(this).off("change");
-			$(this).data('pre_change', $(this).val());
+			// $(this).data('pre_change', $(this).val());
 			$(this).on("change", function() {
 				var before_change = $(this).data('pre_change');
 				if ($(this).val() != before_change) self.modify_widget(this);
 				$(this).data('pre_change', $(this).val());
 			}).change();
-			self.modify_widget(this);
+			// self.modify_widget(this);
 		});
 		$('.form-row select.query-field').each(function() {
 			$(this).off("change");
@@ -127,8 +146,7 @@ var OperatorHandlers = function($) {
 				$(this).data('pre_change', $(this).val());
 			}).change();
 		});
-		self.field_selected($('.form-row select.query-field').first());
-
+		// self.field_selected($('.form-row select.query-field').first());
 	};
 
 	self.destroy = function() {

--- a/advanced_filters/templates/admin/advanced_filters/change_form.html
+++ b/advanced_filters/templates/admin/advanced_filters/change_form.html
@@ -11,7 +11,6 @@
 	<form novalidate {% if has_file_field %}enctype="multipart/form-data" {% endif %}action="{{ form_url }}" method="post" id="{{ opts.model_name }}_form">{% csrf_token %}{% block form_top %}{% endblock %}
 		{% with adminform.form.fields_formset as formset %}
 			<div id="advanced_filters">
-				<h1>{% trans "Change advanced filter" %}:</h1>
 					{% csrf_token %}
 					{{ formset.management_form }}
 					<!-- Fieldsets -->

--- a/advanced_filters/templates/admin/common_js_init.html
+++ b/advanced_filters/templates/admin/common_js_init.html
@@ -20,7 +20,7 @@
 					$.fn.tabularFormset.default_added(row);
 				},
 				preAdded: function(row) {
-					if (_af_handlers) _af_handlers.destroy();  // cleanup
+					// if (_af_handlers) _af_handlers.destroy();  // cleanup
 				}
 		});
 	})(django.jQuery);


### PR DESCRIPTION
CHANGES:
1. Templates:
    - Removed the title inside the change_form template.
    - Commented the _af_handler.destroy() call inside common_js_init because I didn't want to clean up
      every time the add rule button was pressed.
2. Forms:
    - Changed isnull operator from None to 'None' (Before it wasn't working and with 'None' worked
      perfectly).
    - The value field now is not required anymore if you select one of these operators: 'isnull', 'istrue, 
      'isfalse' (Also the value field becomes a readonly field, in these cases).
    - I also removed the part that auto-selects the range operator with datetime fields.
      This was creating some issues and I thought it was a useless feature to keep in so I get rid of 
      that part.
3. Static:
    - Added try-catch when using Django-Grappelli and JQuery-UI
    - Changed the modify_widget 
    - I found  some functions that were called twice with out any valid reason, I commented that parts 
      and this corrected some bugs (for example: now range operator works properly).
    - I also commented the field_selected(...).first() call because I thought that it didn't make any 
      sense to re-initiate the first rule (this problem was forcing you to use always an equal operator as 
      your first rule) .
    - I also changed the initialize_select2 function to set the autocomplete only with foreign keys and 
      'iexact' operator.