### PR TITLE
Fixed sort on None fields

### DIFF
--- a/advanced_filters/views.py
+++ b/advanced_filters/views.py
@@ -1,4 +1,3 @@
-from operator import itemgetter
 import logging
 
 from django.apps import apps
@@ -72,6 +71,6 @@ class GetFieldChoices(CsrfExemptMixin, StaffuserRequiredMixin,
                     choices = []
 
         results = [{'id': c[0], 'text': force_str(c[1])} for c in sorted(
-                   choices, key=itemgetter(0))]
+                   choices, key=lambda x: (x[0] is not None, x[0]))]
 
         return self.render_json_response({'results': results})

--- a/tests/customers/migrations/0001_initial.py
+++ b/tests/customers/migrations/0001_initial.py
@@ -25,7 +25,7 @@ class Migration(migrations.Migration):
                 ('last_login', models.DateTimeField(blank=True, null=True, verbose_name='last login')),
                 ('language', models.CharField(choices=[(b'en', b'English'), (b'sp', b'Spanish'), (b'it', b'Italian')], default=b'en', max_length=8)),
                 ('email', models.EmailField(blank=True, max_length=254, verbose_name='email address')),
-                ('first_name', models.CharField(blank=True, max_length=30, verbose_name='first name')),
+                ('first_name', models.CharField(null=True, max_length=30, verbose_name='first name')),
                 ('last_name', models.CharField(blank=True, max_length=30, verbose_name='last name')),
                 ('is_active', models.BooleanField(default=True, help_text='Designates whether this user should be treated as active. Unselect this instead of deleting accounts.', verbose_name='active')),
                 ('date_joined', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date joined')),

--- a/tests/customers/models.py
+++ b/tests/customers/models.py
@@ -15,7 +15,7 @@ class Client(AbstractBaseUser):
     language = models.CharField(max_length=8, choices=VALID_LANGUAGES,
                                 default='en')
     email = models.EmailField(_('email address'), blank=True)
-    first_name = models.CharField(_('first name'), max_length=30, blank=True)
+    first_name = models.CharField(_('first name'), max_length=30, null=True)
     last_name = models.CharField(_('last name'), max_length=30, blank=True)
     is_active = models.BooleanField(
         _('active'), default=True,

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -27,4 +27,5 @@ class ClientFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = 'customers.Client'
 
+    first_name = factory.faker.Faker('first_name')
     email = factory.Sequence(lambda n: 'c%d@foo.com' % n)


### PR DESCRIPTION
Closes #98 

The current fix allows choices to contains None values and put them in first position like this: `[{'id': None, 'text': None}, {'id': 'bar', 'text': 'bar'} ,{'id': 'foo', 'text': 'foo'}, ...]`. I hope it doesn't break somewhere later, maybe we don't want to add `None` values inside choices ? I am not sure where the choices are used. It seems it is for the autocompletion of the field when creating a filter but the completion doesn't seem to work on my side (maybe there is another bug somewhere ?).

At least this doesn't raise an exception :)
