### PR TITLE
Update django-braces

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Requirements
 ============
 
 -  Django >= 1.9 (Django 1.9 - 3.0 on Python 2/3/PyPy3)
--  django-braces >= 1.4, < 1.14.0
+-  django-braces >= 1.4, <= 1.14.0
 -  simplejson >= 3.6.5, < 4
 
 

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     packages=find_packages(exclude=['tests*', 'tests.*', '*.tests']),
     include_package_data=True,
     install_requires=[
-        'django-braces>=1.4.0,<1.14.0',
+        'django-braces>=1.4.0,<=1.14.0',
         'simplejson>=3.6.5,<4',
     ],
     extras_require=dict(test=TEST_REQS),


### PR DESCRIPTION
Change of requirements django-braces <= 1.14, to correct incompatibility with Django 3.

[Pull request: Add compatibility for Django 3.0](https://github.com/brack3t/django-braces/pull/256)
[Release django-braces v1.14.0](https://github.com/brack3t/django-braces/releases/tag/v1.14.0)

I will include in a future pull request the update of the tox to include versions of Django 3.