### PR TITLE
fix: move from ugettext to gettext

### DIFF
--- a/advanced_filters/admin.py
+++ b/advanced_filters/admin.py
@@ -5,10 +5,16 @@ from django.contrib import admin, messages
 from django.contrib.admin.utils import unquote
 from django.http import HttpResponseRedirect
 from django.shortcuts import resolve_url
-from django.utils.translation import ugettext_lazy as _
 
 from .forms import AdvancedFilterForm
 from .models import AdvancedFilter
+
+# django < 1.9 support
+from django import VERSION
+if VERSION >= (2, 0):
+    from django.utils.translation import gettext_lazy as _
+else:
+    from django.utils.translation import ugettext_lazy as _
 
 
 logger = logging.getLogger('advanced_filters.admin')

--- a/advanced_filters/forms.py
+++ b/advanced_filters/forms.py
@@ -15,18 +15,22 @@ from django.db.models import Q
 from django.db.models.fields import DateField
 from django.forms.formsets import formset_factory, BaseFormSet
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
 from six.moves import range, reduce
 from django.utils.text import capfirst
-
-import django
 
 from .models import AdvancedFilter
 from .form_helpers import CleanWhiteSpacesMixin,  VaryingTypeCharField
 
+# django < 1.9 support
+from django import VERSION
+if VERSION >= (2, 0):
+    from django.utils.translation import gettext_lazy as _
+else:
+    from django.utils.translation import ugettext_lazy as _
+
 
 # django < 1.9 support
-USE_VENDOR_DIR = django.VERSION >= (1, 9)
+USE_VENDOR_DIR = VERSION >= (1, 9)
 logger = logging.getLogger('advanced_filters.forms')
 
 # select2 location can be modified via settings

--- a/advanced_filters/models.py
+++ b/advanced_filters/models.py
@@ -1,9 +1,15 @@
 from django.conf import settings
 from django.db import models
 from django.db.models import Q
-from django.utils.translation import ugettext_lazy as _
 
 from .q_serializer import QSerializer
+
+# django < 1.9 support
+from django import VERSION
+if VERSION >= (2, 0):
+    from django.utils.translation import gettext_lazy as _
+else:
+    from django.utils.translation import ugettext_lazy as _
 
 
 class UserLookupManager(models.Manager):

--- a/tests/customers/models.py
+++ b/tests/customers/models.py
@@ -1,7 +1,13 @@
 from django.contrib.auth.models import AbstractBaseUser
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+
+# django < 1.9 support
+from django import VERSION
+if VERSION >= (2, 0):
+    from django.utils.translation import gettext_lazy as _
+else:
+    from django.utils.translation import ugettext_lazy as _
 
 
 class Client(AbstractBaseUser):


### PR DESCRIPTION
ugettext() is an alias of gettext() since Django 2.0
In Django > 3.0 it generates RemovedInDjango40Warning