### PR TITLE
feat(url): Use path instead of url if available

### DIFF
--- a/advanced_filters/urls.py
+++ b/advanced_filters/urls.py
@@ -1,14 +1,30 @@
-from django.conf.urls import url
+try:
+    from django.urls import path
+except ImportError:
+    path = None
+    from django.conf.urls import url
 
 from advanced_filters.views import GetFieldChoices
 
-urlpatterns = [
-    url(r'^field_choices/(?P<model>.+)/(?P<field_name>.+)/?',
-        GetFieldChoices.as_view(),
-        name='afilters_get_field_choices'),
+if path:
+    urlpatterns = [
+        path('field_choices/<str:model>/<str:field_name>/',
+            GetFieldChoices.as_view(),
+            name='afilters_get_field_choices'),
 
-    # only to allow building dynamically
-    url(r'^field_choices/$',
-        GetFieldChoices.as_view(),
-        name='afilters_get_field_choices'),
-]
+        # only to allow building dynamically
+        path('field_choices/',
+            GetFieldChoices.as_view(),
+            name='afilters_get_field_choices'),
+    ]
+else:
+    urlpatterns = [
+        url(r'^field_choices/(?P<model>.+)/(?P<field_name>.+)/?',
+            GetFieldChoices.as_view(),
+            name='afilters_get_field_choices'),
+
+        # only to allow building dynamically
+        url(r'^field_choices/$',
+            GetFieldChoices.as_view(),
+            name='afilters_get_field_choices'),
+    ]


### PR DESCRIPTION
Fixes "RemovedInDjango40Warning: django.conf.urls.url() is deprecated in favor of django.urls.re_path()."