### PR TITLE
support custom user model without user groups

### DIFF
--- a/advanced_filters/models.py
+++ b/advanced_filters/models.py
@@ -15,7 +15,8 @@ else:
 class UserLookupManager(models.Manager):
     def filter_by_user(self, user):
         """All filters that should be displayed to a user (by users/group)"""
-
+        if not hasattr(user, 'groups'):
+            return self.filter(users=user)
         return self.filter(Q(users=user) | Q(groups__in=user.groups.all()))
 
 


### PR DESCRIPTION
If no user groups exist, don't query it, so that when you use a custom
user model without groups, that you don't get an error.

Relevant GitHub Issue:
https://github.com/modlinltd/django-advanced-filters/issues/57