### PR TITLE
fix: issue 'AdvancedFilterQueryForm' object has no attribute 'clean_data'

### DIFF
--- a/advanced_filters/forms.py
+++ b/advanced_filters/forms.py
@@ -305,6 +305,10 @@ class AdvancedFilterForm(CleanWhiteSpacesMixin, forms.ModelForm):
         self.initialize_form(instance, self._model, data, extra_form)
 
     def clean(self):
+        for form in self.fields_formset:
+            if not form.is_valid():
+                form.cleaned_data = {'field': 'id', 'DELETE': True}
+                
         cleaned_data = super(AdvancedFilterForm, self).clean()
         if not self.fields_formset.is_valid():
             logger.debug(


### PR DESCRIPTION
Fixing this issue for installation in my project.
Ref: https://github.com/modlinltd/django-advanced-filters/pull/153