### PR TITLE
Fix matching issue

### DIFF
--- a/advanced_filters/urls.py
+++ b/advanced_filters/urls.py
@@ -1,14 +1,14 @@
-from django.urls import path
+from django.urls import re_path
 
 from advanced_filters.views import GetFieldChoices
 
 urlpatterns = [
-    path('field_choices/<model>/<field_name>/',
+    re_path(r'^field_choices/(?P<model>.+)/(?P<field_name>.+)/?',
         GetFieldChoices.as_view(),
         name='afilters_get_field_choices'),
 
     # only to allow building dynamically
-    path('field_choices/',
+    re_path(r'^field_choices/$',
         GetFieldChoices.as_view(),
         name='afilters_get_field_choices'),
 ]


### PR DESCRIPTION
The preexisting code did not match correctly for me in Django 3.2 Python 3.8
This more closely matches the original code using the preferred `re_path` recommended in the Django 3.2 migration