### PR TITLE
+ add optional CSP nonce to allow inline script compliance

### DIFF
--- a/advanced_filters/templates/admin/advanced_filters.html
+++ b/advanced_filters/templates/admin/advanced_filters.html
@@ -63,12 +63,13 @@
 					<br />
 					<input method="POST" type="submit" value="{% trans "Save" %}">
 					<input method="POST" name="_save_goto" type="submit" value="{% trans "Save & Filter Now!" %}">
-					<a href="#" class="grp-button" style="margin:auto" onclick="$.magnificPopup.close();">{% trans "Cancel" %}</a>
+					<a href="#" id="advanced-filters-close-btn" class="grp-button" style="margin:auto">{% trans "Cancel" %}</a>
 				</form>
 
 				{{ advanced_filters.media.js }}
 
-				<script type="text/javascript" charset="utf-8">
+				<script type="text/javascript" charset="utf-8" nonce="{{request.csp_nonce}}">
+					document.getElementById("advanced-filters-close-btn").addEventListener('click', ()=>$.magnificPopup.close());
 					// using django's original jquery, initial formset
 					var FORM_MODEL = undefined;
 					var MODEL_LABEL = '{{ app_label }}.{{ opts.model_name }}';

--- a/advanced_filters/templates/admin/advanced_filters/change_form.html
+++ b/advanced_filters/templates/admin/advanced_filters/change_form.html
@@ -54,7 +54,7 @@
 				{% prepopulated_fields_js %}
 				{{ adminform.media.js }}
 
-				<script type="text/javascript" charset="utf-8">
+				<script type="text/javascript" charset="utf-8" nonce="{{request.csp_nonce}}">
 					// using django's original jquery, initial formset
 					var FORM_MODEL = '{% if adminform %}{{ adminform.form.instance.model }}{% endif %}';
 					var MODEL_LABEL = '{{ app_label }}.{{ opts.model_name }}';

--- a/advanced_filters/templates/admin/common_js_init.html
+++ b/advanced_filters/templates/admin/common_js_init.html
@@ -1,6 +1,6 @@
 {% load i18n static %}
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="{{request.csp_nonce}}">
 	// globals
 	var _af_handlers = window._af_handlers || null;
 	var ADVANCED_FILTER_CHOICES_LOOKUP_URL = "{% url 'afilters_get_field_choices' %}";


### PR DESCRIPTION
Surgical updates to comply with basic CSP. This allows the required inline script for this django extension to run in a safe way.

If [django CSP](https://django-csp.readthedocs.io/en/latest/) is not installed: everything works seamlessly :smile_cat: 

Note: this PR does not cover inline styles but the styles do not block the functionality, only the scripts did.